### PR TITLE
fix: resolve npm deployment and environment variable issues

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,7 +1,7 @@
 name: Publish to NPM
 
 on:
-  # 수동 트리거
+  # 수동 트리거만 사용 (중복 배포 방지)
   workflow_dispatch:
     inputs:
       version:
@@ -13,11 +13,6 @@ on:
           - patch
           - minor
           - major
-  
-  # 또는 태그 푸시 시 자동 트리거
-  push:
-    tags:
-      - 'v*'
 
 jobs:
   test-and-build:
@@ -61,6 +56,20 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      # 버전 업데이트 (수동 트리거 시)
+      - name: Update version
+        run: |
+          git config --local user.email "zoloman316@gmail.com"
+          git config --local user.name "rojojun"
+          npm version ${{ github.event.inputs.version }} -m "chore: release v%s"
+
+      # 태그 푸시
+      - name: Push changes and tags
+        run: |
+          git push
+          git push --tags
+
+      # .env 파일 생성 (빌드 시 환경 변수 주입용)
       - name: Create .env file
         run: |
           echo "GEMINI_QUEUE_SERVER_API=${{ secrets.GEMINI_API_URL }}" > .env
@@ -68,14 +77,6 @@ jobs:
 
       - name: Build package
         run: npm run build
-
-      # 버전 업데이트 (수동 트리거 시)
-      - name: Update version
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          git config --local user.email "zoloman316@gmail.com"
-          git config --local user.name "rojojun"
-          npm version ${{ github.event.inputs.version }} --no-git-tag-version
 
       # package.json에서 버전 읽기
       - name: Get package version

--- a/build.js
+++ b/build.js
@@ -1,0 +1,51 @@
+const esbuild = require('esbuild');
+const dotenv = require('dotenv');
+
+// .env 파일 로드
+dotenv.config();
+
+// 환경 변수 확인
+const geminiApiUrl = process.env.GEMINI_QUEUE_SERVER_API;
+
+if (!geminiApiUrl) {
+    console.warn('Warning: GEMINI_QUEUE_SERVER_API not found in environment variables');
+    console.warn('The built package will require users to set this environment variable');
+}
+
+console.log('Building with esbuild...');
+console.log(`GEMINI_QUEUE_SERVER_API: ${geminiApiUrl ? '✓ Set' : '✗ Not set'}`);
+
+esbuild.build({
+    entryPoints: ['src/index.ts'],
+    bundle: true,
+    platform: 'node',
+    target: 'node18',
+    outdir: 'dist',
+    format: 'cjs',
+    banner: {
+        js: '#!/usr/bin/env node',
+    },
+    // 환경 변수를 코드에 주입
+    define: {
+        'process.env.GEMINI_QUEUE_SERVER_API': geminiApiUrl
+            ? JSON.stringify(geminiApiUrl)
+            : 'process.env.GEMINI_QUEUE_SERVER_API',
+    },
+    // dependencies를 번들에 포함하지 않음 (사용자가 npm install로 설치)
+    external: [
+        'axios',
+        'chalk-animation',
+        'clipboardy',
+        'dotenv',
+        'inquirer',
+        'ora',
+        'gradient-string',
+    ],
+    minify: false,
+    sourcemap: false,
+}).then(() => {
+    console.log('✓ Build completed successfully!');
+}).catch((error) => {
+    console.error('✗ Build failed:', error);
+    process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   },
   "types": "./dist/index.d.ts",
   "files": [
-    "dist",
-    ".env"
+    "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "node build.js",
+    "build:tsc": "tsc",
     "dev": "tsx src/index.ts",
     "start": "npm run build && node dist/index.js",
     "prepublishOnly": "npm run build"
@@ -39,6 +39,7 @@
     "@types/gradient-string": "^1.1.6",
     "@types/inquirer": "^9.0.9",
     "@types/node": "^24.3.1",
+    "esbuild": "^0.25.11",
     "tsx": "^4.20.6",
     "typescript": "^5.9.2"
   }


### PR DESCRIPTION
- Add esbuild for bundling with environment variable injection
- Remove .env from npm package files
- Update npm-publish workflow to prevent duplicate deployments
- Remove tag-based auto-trigger (manual workflow_dispatch only)
- Delete duplicate v1.1.0 tag

This fixes the issue where GEMINI_QUEUE_SERVER_API was not available in the deployed npm package, and prevents future duplicate version deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)